### PR TITLE
Update the list of removed guardrails to include `jailbreak_detection`

### DIFF
--- a/scripts/provider-list.yaml
+++ b/scripts/provider-list.yaml
@@ -19,3 +19,4 @@ closed_source_guardrails:
   - "clavata"
   - "prompt_security"
   - "gcp_moderate_text"
+  - "jailbreak_detection"


### PR DESCRIPTION
This PR temporarily disables `jailbreak_detection` to deal with [RHOAIENG-54750](https://redhat.atlassian.net/browse/RHOAIENG-54750)