### PR TITLE
Feat: Add initial support for v1/messages

### DIFF
--- a/nemoguardrails/server/anthropic_serving.py
+++ b/nemoguardrails/server/anthropic_serving.py
@@ -1,0 +1,477 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anthropic Messages API adapter for NeMo Guardrails.
+
+Thin adapter layer: accepts Anthropic /v1/messages requests, converts
+to OpenAI chat-completion format, delegates to the existing
+chat_completion handler for config resolution / rails / generation,
+then converts the response back to Anthropic format.
+
+Based on vLLM's Anthropic Messages API compatibility layer.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any, AsyncIterable, AsyncIterator, Literal
+
+from fastapi import HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from .schemas.anthropic import (
+    AnthropicContentBlock,
+    AnthropicDelta,
+    AnthropicError,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+    AnthropicStreamEvent,
+    AnthropicUsage,
+)
+from .schemas.openai import GuardrailsChatCompletionRequest, GuardrailsDataInput
+
+log = logging.getLogger(__name__)
+
+_STOP_REASON_MAP: dict[str, str] = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "content_filter": "end_turn",
+}
+
+
+# ---------------------------------------------------------------------------
+# Request conversion: Anthropic -> OpenAI
+# ---------------------------------------------------------------------------
+
+
+def _convert_image_source_to_url(source: dict[str, Any]) -> str:
+    """Convert Anthropic image source to OpenAI data-URI."""
+    source_type = source.get("type", "base64")
+    if source_type == "base64":
+        media_type = source.get("media_type", "image/jpeg")
+        data = source.get("data", "")
+        return f"data:{media_type};base64,{data}"
+    if source_type == "url":
+        url = source.get("url", "")
+        return url if url.startswith("data:") else url
+    return f"data:image/jpeg;base64,{source.get('data', '')}"
+
+
+def _convert_system_to_openai(
+    system: Any | None,
+) -> list[dict[str, str]]:
+    """Convert Anthropic ``system`` field to OpenAI system messages."""
+    if system is None:
+        return []
+    if isinstance(system, str):
+        return [{"role": "system", "content": system}]
+    parts: list[str] = []
+    for block in system:
+        if block.type == "text" and block.text:
+            if block.text.startswith("x-anthropic-billing-header"):
+                continue
+            parts.append(block.text)
+    return [{"role": "system", "content": "\n".join(parts)}] if parts else []
+
+
+def _convert_messages_to_openai(
+    messages: list[Any],
+) -> list[dict[str, Any]]:
+    """Convert AnthropicMessage objects to OpenAI message dicts."""
+    out: list[dict[str, Any]] = []
+    reasoning_parts: list[str] = []
+
+    for msg in messages:
+        openai_msg: dict[str, Any] = {"role": msg.role}
+
+        if isinstance(msg.content, str):
+            openai_msg["content"] = msg.content
+        else:
+            tool_calls: list[dict[str, Any]] = []
+            content_parts: list[dict[str, Any]] = []
+
+            for block in msg.content:
+                if block.type == "text" and block.text:
+                    content_parts.append({"type": "text", "text": block.text})
+                elif block.type == "image" and block.source:
+                    image_url = _convert_image_source_to_url(block.source)
+                    content_parts.append({"type": "image_url", "image_url": {"url": image_url}})
+                elif block.type == "thinking" and block.thinking is not None:
+                    reasoning_parts.append(block.thinking)
+                elif block.type == "redacted_thinking":
+                    pass
+                elif block.type == "tool_use":
+                    tool_calls.append(
+                        {
+                            "id": block.id or f"call_{int(time.time())}",
+                            "type": "function",
+                            "function": {
+                                "name": block.name or "",
+                                "arguments": json.dumps(block.input or {}),
+                            },
+                        }
+                    )
+                elif block.type == "tool_result":
+                    tool_text = str(block.content) if block.content else ""
+                    out.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": block.tool_use_id or "",
+                            "content": tool_text or "",
+                        }
+                    )
+
+            if tool_calls:
+                openai_msg["tool_calls"] = tool_calls
+            if content_parts:
+                has_non_text = any(p.get("type") != "text" for p in content_parts)
+                if has_non_text:
+                    openai_msg["content"] = content_parts
+                else:
+                    """
+                    Warning: this concatenates multiple messages into a single OpenAI message.
+
+                    This is necessary for compatibility with the rest of the NeMo Guardrails library
+                    but introduces a different behavior as compared to the vLLM conversions.
+                    """
+                    openai_msg["content"] = "\n".join(p["text"] for p in content_parts if p.get("text"))
+            if reasoning_parts:
+                openai_msg["reasoning"] = "".join(reasoning_parts)
+
+        if not (msg.role == "user" and "content" not in openai_msg):
+            out.append(openai_msg)
+        reasoning_parts = []
+
+    return out
+
+
+def _anthropic_to_openai_request(
+    body: AnthropicMessagesRequest,
+) -> GuardrailsChatCompletionRequest:
+    """Build a GuardrailsChatCompletionRequest from an Anthropic request."""
+    openai_messages = _convert_messages_to_openai(body.messages)
+    system_messages = _convert_system_to_openai(body.system)
+
+    return GuardrailsChatCompletionRequest(
+        model=body.model,
+        messages=system_messages + openai_messages,
+        max_tokens=body.max_tokens,
+        temperature=body.temperature,
+        top_p=body.top_p,
+        stop=body.stop_sequences,
+        stream=body.stream or False,
+        guardrails=GuardrailsDataInput(config_id=body.config_id),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-streaming response conversion: OpenAI -> Anthropic
+# ---------------------------------------------------------------------------
+
+
+def _openai_to_anthropic_response(
+    result: Any,
+    model: str,
+) -> AnthropicMessagesResponse:
+    """Convert an OpenAI ChatCompletion to AnthropicMessagesResponse."""
+    content: list[AnthropicContentBlock] = []
+    stop_reason: str = "end_turn"
+
+    if hasattr(result, "choices") and result.choices:
+        choice = result.choices[0]
+        if hasattr(choice, "message") and choice.message:
+            text = choice.message.content or ""
+            if text:
+                content.append(AnthropicContentBlock(type="text", text=text))
+            fr = getattr(choice, "finish_reason", "stop") or "stop"
+            stop_reason = _STOP_REASON_MAP.get(fr, "end_turn")
+
+    return AnthropicMessagesResponse(
+        id=f"msg_{int(time.time() * 1000)}",
+        content=content,
+        model=model,
+        stop_reason=stop_reason,  # type: ignore[arg-type]
+        usage=AnthropicUsage(input_tokens=0, output_tokens=0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming conversion: OpenAI SSE -> Anthropic SSE
+# ---------------------------------------------------------------------------
+
+
+def _wrap_sse(data: str, event: str) -> str:
+    return f"event: {event}\ndata: {data}\n\n"
+
+
+def _parse_sse_line(line: str | bytes) -> dict[str, Any] | None:
+    """Extract a JSON dict from an SSE ``data:`` line, or None."""
+    text = line.decode("utf-8") if isinstance(line, bytes) else line
+    text = text.strip()
+    if not text.startswith("data: "):
+        return None
+    payload = text[6:]
+    if payload == "[DONE]":
+        return None
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
+
+
+async def _openai_sse_to_anthropic_sse(
+    body_iterator: AsyncIterable[Any],
+    model: str,
+) -> AsyncIterator[str]:
+    """Convert an OpenAI SSE stream to Anthropic SSE events.
+
+    Consumes the ``body_iterator`` from a StreamingResponse returned by
+    ``chat_completion`` and re-emits Anthropic-protocol events.
+    """
+    finish_reason: str | None = None
+    state: dict[str, Any] = {
+        "content_block_index": 0,
+        "block_type": None,
+        "block_index": None,
+        "_tool_use_id": None,
+        "_thinking_signature": None,
+        "_signature_emitted": False,
+    }
+    tool_index_to_id: dict[int, str] = {}
+
+    def _stop_active_block() -> list[str]:
+        events: list[str] = []
+        if state["block_type"] is None:
+            return events
+        if (
+            state["block_type"] == "thinking"
+            and state.get("_thinking_signature")
+            and not state.get("_signature_emitted", False)
+        ):
+            sig_ev = AnthropicStreamEvent(
+                index=state["block_index"],
+                type="content_block_delta",
+                delta=AnthropicDelta(
+                    type="signature_delta",
+                    signature=state["_thinking_signature"],
+                ),
+            )
+            events.append(_wrap_sse(sig_ev.model_dump_json(exclude_unset=True), "content_block_delta"))
+            state["_signature_emitted"] = True
+
+        stop_ev = AnthropicStreamEvent(index=state["block_index"], type="content_block_stop")
+        events.append(_wrap_sse(stop_ev.model_dump_json(exclude_unset=True), "content_block_stop"))
+        state["block_type"] = None
+        state["block_index"] = None
+        state["_tool_use_id"] = None
+        state["_thinking_signature"] = None
+        state["_signature_emitted"] = False
+        state["content_block_index"] += 1
+        return events
+
+    def _start_block(block: AnthropicContentBlock) -> str:
+        if block.type == "thinking":
+            state["_thinking_signature"] = uuid.uuid4().hex
+            state["_signature_emitted"] = False
+        else:
+            state["_thinking_signature"] = None
+            state["_signature_emitted"] = True
+
+        state["block_type"] = block.type
+        state["block_index"] = state["content_block_index"]
+        state["_tool_use_id"] = block.id if block.type == "tool_use" and block.id else None
+
+        ev = AnthropicStreamEvent(
+            index=state["content_block_index"],
+            type="content_block_start",
+            content_block=block,
+        )
+        state["content_block_index"] += 1
+        return _wrap_sse(ev.model_dump_json(exclude_unset=True), "content_block_start")
+
+    try:
+        first_chunk = True
+
+        async for sse_line in body_iterator:
+            chunk_data = _parse_sse_line(sse_line)
+            if chunk_data is None:
+                continue
+
+            # Check for error payloads
+            if "error" in chunk_data and "choices" not in chunk_data:
+                err_msg = chunk_data["error"].get("message", "Unknown error")
+                err_ev = AnthropicStreamEvent(
+                    type="error",
+                    error=AnthropicError(type="internal_error", message=err_msg),
+                )
+                yield _wrap_sse(err_ev.model_dump_json(exclude_unset=True), "error")
+                return
+
+            choices = chunk_data.get("choices", [])
+
+            if first_chunk:
+                first_chunk = False
+                usage = chunk_data.get("usage") or {}
+                start_ev = AnthropicStreamEvent(
+                    type="message_start",
+                    message=AnthropicMessagesResponse(
+                        id=f"msg_{int(time.time() * 1000)}",
+                        content=[],
+                        model=model,
+                        stop_reason=None,
+                        stop_sequence=None,
+                        usage=AnthropicUsage(
+                            input_tokens=usage.get("prompt_tokens", 0) or 0,
+                            output_tokens=usage.get("completion_tokens", 0) or 0,
+                        ),
+                    ),
+                )
+                yield _wrap_sse(start_ev.model_dump_json(exclude_unset=True), "message_start")
+
+            if not choices:
+                for ev in _stop_active_block():
+                    yield ev
+                sr = _STOP_REASON_MAP.get(finish_reason) if finish_reason else "end_turn"
+                safe_sr: Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"] | None = sr  # type: ignore[assignment]
+                delta_ev = AnthropicStreamEvent(
+                    type="message_delta",
+                    delta=AnthropicDelta(stop_reason=safe_sr),
+                    usage=AnthropicUsage(
+                        input_tokens=0,
+                        output_tokens=chunk_data.get("usage", {}).get("completion_tokens", 0) or 0,
+                    ),
+                )
+                yield _wrap_sse(delta_ev.model_dump_json(exclude_unset=True), "message_delta")
+                continue
+
+            choice = choices[0]
+            delta = choice.get("delta", {})
+            fr = choice.get("finish_reason")
+            if fr:
+                finish_reason = fr
+
+            # Reasoning / thinking
+            reasoning_delta = delta.get("reasoning")
+            if reasoning_delta is not None and reasoning_delta != "":
+                if state["block_type"] != "thinking":
+                    for ev in _stop_active_block():
+                        yield ev
+                    yield _start_block(AnthropicContentBlock(type="thinking", thinking=""))
+                ev = AnthropicStreamEvent(
+                    index=state["block_index"] if state["block_index"] is not None else state["content_block_index"],
+                    type="content_block_delta",
+                    delta=AnthropicDelta(type="thinking_delta", thinking=reasoning_delta),
+                )
+                yield _wrap_sse(ev.model_dump_json(exclude_unset=True), "content_block_delta")
+
+            # Text content
+            if "content" in delta and delta["content"] is not None and delta["content"] != "":
+                text_val = delta["content"]
+                if state["block_type"] != "text":
+                    for ev in _stop_active_block():
+                        yield ev
+                    yield _start_block(AnthropicContentBlock(type="text", text=""))
+                ev = AnthropicStreamEvent(
+                    type="content_block_delta",
+                    delta=AnthropicDelta(type="text_delta", text=text_val),
+                    index=state["block_index"],
+                )
+                yield _wrap_sse(ev.model_dump_json(exclude_unset=True), "content_block_delta")
+
+            # Tool-call deltas
+            for tc in delta.get("tool_calls", []):
+                fn = tc.get("function", {})
+                fn_name = fn.get("name")
+                fn_args = fn.get("arguments", "")
+                tc_id = tc.get("id")
+                tc_index = tc.get("index")
+
+                if tc_id is not None:
+                    if tc_index is not None:
+                        tool_index_to_id[tc_index] = tc_id
+                    if tc_id and fn_name and state.get("_tool_use_id") != tc_id:
+                        for ev in _stop_active_block():
+                            yield ev
+                        yield _start_block(AnthropicContentBlock(type="tool_use", id=tc_id, name=fn_name, input={}))
+                        state["_tool_use_id"] = tc_id
+                    if fn_args and state.get("_tool_use_id") == tc_id:
+                        ev = AnthropicStreamEvent(
+                            type="content_block_delta",
+                            delta=AnthropicDelta(type="input_json_delta", partial_json=fn_args),
+                            index=state["block_index"],
+                        )
+                        yield _wrap_sse(ev.model_dump_json(exclude_unset=True), "content_block_delta")
+                else:
+                    tool_use_id = tool_index_to_id.get(tc_index) if tc_index is not None else None
+                    if tool_use_id and fn_args and state.get("_tool_use_id") == tool_use_id:
+                        ev = AnthropicStreamEvent(
+                            type="content_block_delta",
+                            delta=AnthropicDelta(type="input_json_delta", partial_json=fn_args),
+                            index=state["block_index"],
+                        )
+                        yield _wrap_sse(ev.model_dump_json(exclude_unset=True), "content_block_delta")
+
+    finally:
+        stop_ev = AnthropicStreamEvent(type="message_stop")
+        yield _wrap_sse(stop_ev.model_dump_json(exclude_unset=True), "message_stop")
+
+
+# ---------------------------------------------------------------------------
+# Anthropic error helper
+# ---------------------------------------------------------------------------
+
+
+def _anthropic_error(status_code: int, error_type: str, message: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={"type": "error", "error": {"type": error_type, "message": message}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI route registration
+# ---------------------------------------------------------------------------
+
+
+def register_anthropic_routes(fastapi_app: Any) -> None:
+    """Register the /v1/messages endpoint on the given FastAPI app."""
+
+    @fastapi_app.post(
+        "/v1/messages",
+        response_model=AnthropicMessagesResponse,
+        response_model_exclude_none=True,
+    )
+    async def anthropic_messages(
+        body: AnthropicMessagesRequest,
+        request: Request,
+    ):
+        from .api import chat_completion
+
+        openai_body = _anthropic_to_openai_request(body)
+
+        try:
+            result = await chat_completion(openai_body, request)
+        except HTTPException as exc:
+            return _anthropic_error(exc.status_code, "invalid_request_error", str(exc.detail))
+
+        if isinstance(result, StreamingResponse):
+            return StreamingResponse(
+                _openai_sse_to_anthropic_sse(result.body_iterator, body.model),
+                media_type="text/event-stream",
+            )
+
+        return _openai_to_anthropic_response(result, body.model)

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -47,6 +47,7 @@ from nemoguardrails.rails.llm.options import (
     GenerationResponse,
     GenerationStats,
 )
+from nemoguardrails.server.anthropic_serving import register_anthropic_routes
 from nemoguardrails.server.datastore.datastore import DataStore
 from nemoguardrails.server.schemas.openai import (
     GuardrailCheckResponse,
@@ -1339,3 +1340,8 @@ class GuardrailsConfigurationError(Exception):
 #
 #
 # register_exception(app)
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages API (/v1/messages)
+# ---------------------------------------------------------------------------
+register_anthropic_routes(app)

--- a/nemoguardrails/server/schemas/anthropic.py
+++ b/nemoguardrails/server/schemas/anthropic.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Anthropic Messages API protocol schemas for the NeMo Guardrails server.
+
+Supports the /v1/messages endpoint which accepts Anthropic API format
+requests and converts them to OpenAI Chat Completions internally.
+
+Schema definitions match vLLM's Anthropic API compatibility layer to
+ensure full protocol compatibility.
+"""
+
+import time
+from typing import Any, Literal, Optional, Union
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class AnthropicError(BaseModel):
+    """Error structure for Anthropic API."""
+
+    type: str
+    message: str
+
+
+class AnthropicErrorResponse(BaseModel):
+    """Error response structure for Anthropic API."""
+
+    type: Literal["error"] = "error"
+    error: AnthropicError
+
+
+class AnthropicUsage(BaseModel):
+    """Token usage information."""
+
+    input_tokens: int
+    output_tokens: int
+    cache_creation_input_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None
+
+
+class AnthropicContentBlock(BaseModel):
+    """Content block in message."""
+
+    type: Literal[
+        "text",
+        "image",
+        "tool_use",
+        "tool_result",
+        "thinking",
+        "redacted_thinking",
+    ]
+    text: Optional[str] = None
+    # For image content
+    source: Optional[dict[str, Any]] = None
+    # For tool use/result
+    id: Optional[str] = None
+    tool_use_id: Optional[str] = None
+    name: Optional[str] = None
+    input: Optional[dict[str, Any]] = None
+    content: Optional[Union[str, list[dict[str, Any]]]] = None
+    is_error: Optional[bool] = None
+    # For thinking content
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
+    # For redacted thinking content (safety-filtered by the API)
+    data: Optional[str] = None
+
+
+class AnthropicMessage(BaseModel):
+    """Message structure."""
+
+    role: Literal["user", "assistant"]
+    content: Union[str, list[AnthropicContentBlock]]
+
+
+class AnthropicTool(BaseModel):
+    """Tool definition."""
+
+    name: str
+    description: Optional[str] = None
+    input_schema: dict[str, Any]
+
+    @field_validator("input_schema")
+    @classmethod
+    def validate_input_schema(cls, v: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(v, dict):
+            raise ValueError("input_schema must be a dictionary")
+        if "type" not in v:
+            v["type"] = "object"  # Default to object type
+        return v
+
+
+class AnthropicToolChoice(BaseModel):
+    """Tool Choice definition."""
+
+    type: Literal["auto", "any", "tool", "none"]
+    name: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_name_required_for_tool(self) -> "AnthropicToolChoice":
+        if self.type == "tool" and not self.name:
+            raise ValueError("tool_choice.name is required when type is 'tool'")
+        return self
+
+
+class AnthropicMessagesRequest(BaseModel):
+    """Anthropic Messages API request."""
+
+    model: str
+    messages: list[AnthropicMessage]
+    max_tokens: int
+    system: Optional[Union[str, list[AnthropicContentBlock]]] = None
+    stop_sequences: Optional[list[str]] = None
+    stream: Optional[bool] = False
+    temperature: Optional[float] = None
+    tool_choice: Optional[AnthropicToolChoice] = None
+    tools: Optional[list[AnthropicTool]] = None
+    top_p: Optional[float] = None
+
+    # NeMo-specific: optional guardrails config
+    config_id: Optional[str] = Field(
+        default=None,
+        description="Guardrails configuration ID to apply to this request.",
+    )
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, v: str) -> str:
+        if not v:
+            raise ValueError("Model is required")
+        return v
+
+    @field_validator("max_tokens")
+    @classmethod
+    def validate_max_tokens(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("max_tokens must be positive")
+        return v
+
+
+class AnthropicMessagesResponse(BaseModel):
+    """Anthropic Messages API response."""
+
+    id: str = ""
+    type: Literal["message"] = "message"
+    role: Literal["assistant"] = "assistant"
+    content: list[AnthropicContentBlock]
+    model: str
+    stop_reason: Optional[Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]] = None
+    stop_sequence: Optional[str] = None
+    usage: Optional[AnthropicUsage] = None
+
+    class Config:
+        extra = "allow"
+
+    def model_post_init(self, __context: Any) -> None:  # pragma: no cover
+        if not self.id:
+            self.id = f"msg_{int(time.time() * 1000)}"
+
+
+class AnthropicDelta(BaseModel):
+    """Delta for streaming responses."""
+
+    type: Optional[
+        Literal[
+            "text_delta",
+            "input_json_delta",
+            "thinking_delta",
+            "signature_delta",
+        ]
+    ] = None
+    text: Optional[str] = None
+    thinking: Optional[str] = None
+    signature: Optional[str] = None
+    partial_json: Optional[str] = None
+
+    # Message delta
+    stop_reason: Optional[Literal["end_turn", "max_tokens", "stop_sequence", "tool_use"]] = None
+    stop_sequence: Optional[str] = None
+
+
+class AnthropicStreamEvent(BaseModel):
+    """Streaming event."""
+
+    type: Literal[
+        "message_start",
+        "message_delta",
+        "message_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "ping",
+        "error",
+    ]
+    message: Optional["AnthropicMessagesResponse"] = None
+    delta: Optional[AnthropicDelta] = None
+    content_block: Optional[AnthropicContentBlock] = None
+    index: Optional[int] = None
+    error: Optional[AnthropicError] = None
+    usage: Optional[AnthropicUsage] = None

--- a/tests/server/test_anthropic_messages.py
+++ b/tests/server/test_anthropic_messages.py
@@ -1,0 +1,473 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for /v1/messages (Anthropic Messages API adapter).
+
+Covers:
+1. Request conversion (Anthropic -> OpenAI format)
+2. Response conversion (OpenAI -> Anthropic format)
+3. End-to-end via FastAPI TestClient
+4. Streaming SSE conversion
+5. Error handling
+"""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("openai", reason="openai is required for server tests")
+from fastapi.testclient import TestClient
+
+from nemoguardrails.server import api
+from nemoguardrails.server.anthropic_serving import (
+    _anthropic_to_openai_request,
+    _convert_messages_to_openai,
+    _convert_system_to_openai,
+    _openai_to_anthropic_response,
+    _parse_sse_line,
+)
+from nemoguardrails.server.schemas.anthropic import (
+    AnthropicContentBlock,
+    AnthropicMessage,
+    AnthropicMessagesRequest,
+)
+from tests.utils import FakeLLM
+
+client = TestClient(api.app)
+
+_fake_llm = FakeLLM(responses=["I don't know."])
+
+
+def _mock_init_llm_model(**kwargs):
+    _fake_llm.i = 0
+    return _fake_llm
+
+
+@pytest.fixture(scope="function", autouse=True)
+def setup_test_config():
+    test_configs_path = os.path.join(os.path.dirname(__file__), "..", "test_configs")
+    api.app.rails_config_path = os.path.normpath(test_configs_path)
+    api.app.default_config_id = "simple_rails"
+    api.app.single_config_mode = False
+    with patch(
+        "nemoguardrails.rails.llm.llmrails.init_llm_model",
+        side_effect=_mock_init_llm_model,
+    ):
+        yield
+    api.llm_rails_instances.clear()
+
+
+# ── Unit tests: request conversion ──────────────────────────────────
+
+
+class TestConvertSystemToOpenAI:
+    def test_none(self):
+        assert _convert_system_to_openai(None) == []
+
+    def test_string(self):
+        result = _convert_system_to_openai("You are helpful.")
+        assert result == [{"role": "system", "content": "You are helpful."}]
+
+    def test_content_blocks(self):
+        blocks = [
+            AnthropicContentBlock(type="text", text="First."),
+            AnthropicContentBlock(type="text", text="Second."),
+        ]
+        result = _convert_system_to_openai(blocks)
+        assert len(result) == 1
+        assert result[0]["content"] == "First.\nSecond."
+
+    def test_strips_billing_header(self):
+        blocks = [
+            AnthropicContentBlock(type="text", text="x-anthropic-billing-header: abc"),
+            AnthropicContentBlock(type="text", text="Actual system prompt."),
+        ]
+        result = _convert_system_to_openai(blocks)
+        assert result[0]["content"] == "Actual system prompt."
+
+
+class TestConvertMessagesToOpenAI:
+    def test_simple_text(self):
+        msgs = [
+            AnthropicMessage(role="user", content="Hello"),
+            AnthropicMessage(role="assistant", content="Hi there"),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        assert len(result) == 2
+        assert result[0] == {"role": "user", "content": "Hello"}
+        assert result[1] == {"role": "assistant", "content": "Hi there"}
+
+    def test_content_blocks(self):
+        msgs = [
+            AnthropicMessage(
+                role="user",
+                content=[AnthropicContentBlock(type="text", text="What is this?")],
+            ),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        assert result[0]["content"] == "What is this?"
+
+    def test_tool_use_block(self):
+        msgs = [
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    AnthropicContentBlock(
+                        type="tool_use",
+                        id="call_123",
+                        name="get_weather",
+                        input={"city": "London"},
+                    ),
+                ],
+            ),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        assert result[0]["tool_calls"][0]["id"] == "call_123"
+        assert result[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+        assert json.loads(result[0]["tool_calls"][0]["function"]["arguments"]) == {"city": "London"}
+
+    def test_tool_result_block(self):
+        msgs = [
+            AnthropicMessage(
+                role="user",
+                content=[
+                    AnthropicContentBlock(
+                        type="tool_result",
+                        tool_use_id="call_123",
+                        content="72°F",
+                    ),
+                ],
+            ),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        tool_msg = [m for m in result if m["role"] == "tool"]
+        assert len(tool_msg) == 1
+        assert tool_msg[0]["tool_call_id"] == "call_123"
+        assert tool_msg[0]["content"] == "72°F"
+
+    def test_thinking_block(self):
+        msgs = [
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    AnthropicContentBlock(type="thinking", thinking="Let me reason..."),
+                    AnthropicContentBlock(type="text", text="The answer is 42."),
+                ],
+            ),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        assert result[0]["reasoning"] == "Let me reason..."
+        assert result[0]["content"] == "The answer is 42."
+
+    def test_redacted_thinking_skipped(self):
+        msgs = [
+            AnthropicMessage(
+                role="assistant",
+                content=[
+                    AnthropicContentBlock(type="redacted_thinking", data="opaque"),
+                    AnthropicContentBlock(type="text", text="Result."),
+                ],
+            ),
+        ]
+        result = _convert_messages_to_openai(msgs)
+        assert "reasoning" not in result[0]
+        assert result[0]["content"] == "Result."
+
+
+class TestAnthropicToOpenAIRequest:
+    def test_basic_conversion(self):
+        body = AnthropicMessagesRequest(
+            model="claude-3-opus",
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            max_tokens=1024,
+            system="Be helpful.",
+            temperature=0.7,
+            top_p=0.9,
+            stop_sequences=["END"],
+        )
+        result = _anthropic_to_openai_request(body)
+        assert result.model == "claude-3-opus"
+        assert result.max_tokens == 1024
+        assert result.temperature == 0.7
+        assert result.top_p == 0.9
+        assert result.stop == ["END"]
+        assert len(result.messages) == 2
+        assert result.messages[0]["role"] == "system"
+        assert result.messages[1]["role"] == "user"
+
+    def test_config_id_forwarded(self):
+        body = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            config_id="my_config",
+        )
+        result = _anthropic_to_openai_request(body)
+        assert result.guardrails.config_id == "my_config"
+
+    def test_stream_flag(self):
+        body = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+            stream=True,
+        )
+        result = _anthropic_to_openai_request(body)
+        assert result.stream is True
+
+    def test_no_system(self):
+        body = AnthropicMessagesRequest(
+            model="test",
+            messages=[AnthropicMessage(role="user", content="Hi")],
+            max_tokens=100,
+        )
+        result = _anthropic_to_openai_request(body)
+        assert all(m["role"] != "system" for m in result.messages)
+
+
+# ── Unit tests: response conversion ─────────────────────────────────
+
+
+class TestOpenAIToAnthropicResponse:
+    def test_basic_response(self):
+        mock_result = MagicMock()
+        mock_result.choices = [MagicMock()]
+        mock_result.choices[0].message.content = "Hello from the bot!"
+        mock_result.choices[0].finish_reason = "stop"
+
+        response = _openai_to_anthropic_response(mock_result, "test-model")
+        assert response.model == "test-model"
+        assert response.role == "assistant"
+        assert response.type == "message"
+        assert len(response.content) == 1
+        assert response.content[0].type == "text"
+        assert response.content[0].text == "Hello from the bot!"
+        assert response.stop_reason == "end_turn"
+
+    def test_empty_choices(self):
+        mock_result = MagicMock()
+        mock_result.choices = []
+
+        response = _openai_to_anthropic_response(mock_result, "test-model")
+        assert response.content == []
+        assert response.stop_reason == "end_turn"
+
+    def test_length_stop_reason(self):
+        mock_result = MagicMock()
+        mock_result.choices = [MagicMock()]
+        mock_result.choices[0].message.content = "Truncated"
+        mock_result.choices[0].finish_reason = "length"
+
+        response = _openai_to_anthropic_response(mock_result, "test-model")
+        assert response.stop_reason == "max_tokens"
+
+    def test_tool_calls_stop_reason(self):
+        mock_result = MagicMock()
+        mock_result.choices = [MagicMock()]
+        mock_result.choices[0].message.content = ""
+        mock_result.choices[0].finish_reason = "tool_calls"
+
+        response = _openai_to_anthropic_response(mock_result, "test-model")
+        assert response.stop_reason == "tool_use"
+
+
+# ── Unit tests: SSE parsing ─────────────────────────────────────────
+
+
+class TestParseSSELine:
+    def test_valid_json(self):
+        line = 'data: {"choices": [{"delta": {"content": "hi"}}]}\n\n'
+        result = _parse_sse_line(line)
+        assert result is not None
+        assert result["choices"][0]["delta"]["content"] == "hi"
+
+    def test_done_marker(self):
+        assert _parse_sse_line("data: [DONE]\n\n") is None
+
+    def test_non_data_line(self):
+        assert _parse_sse_line("event: message\n") is None
+
+    def test_invalid_json(self):
+        assert _parse_sse_line("data: not-json\n\n") is None
+
+    def test_bytes_input(self):
+        line = b'data: {"choices": []}\n\n'
+        result = _parse_sse_line(line)
+        assert result is not None
+        assert result["choices"] == []
+
+    def test_empty_line(self):
+        assert _parse_sse_line("") is None
+        assert _parse_sse_line("\n") is None
+
+
+# ── Integration tests via TestClient ─────────────────────────────────
+
+
+class TestAnthropicMessagesEndpoint:
+    def test_basic_message(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "message"
+        assert body["role"] == "assistant"
+        assert len(body["content"]) >= 1
+        assert body["content"][0]["type"] == "text"
+        assert body["stop_reason"] == "end_turn"
+
+    def test_with_system_prompt(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "system": "You are a pirate.",
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "message"
+
+    def test_with_config_id(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "config_id": "simple_rails",
+            },
+        )
+        assert response.status_code == 200
+
+    def test_no_config_returns_error(self):
+        api.app.default_config_id = None
+        api.app.single_config_id = None
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        assert response.status_code == 422
+
+    def test_invalid_model_field(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        assert response.status_code == 422
+
+    def test_multi_turn_conversation(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [
+                    {"role": "user", "content": "What is 2+2?"},
+                    {"role": "assistant", "content": "4"},
+                    {"role": "user", "content": "And 3+3?"},
+                ],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "message"
+
+    def test_streaming(self):
+        # input_rails has no output rails, so streaming is allowed
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "stream": True,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "config_id": "input_rails",
+            },
+        )
+        assert response.status_code == 200
+        assert "text/event-stream" in response.headers["content-type"]
+
+        events = []
+        for line in response.text.split("\n"):
+            line = line.strip()
+            if line.startswith("event: "):
+                events.append(line[7:])
+
+        assert "message_start" in events
+        assert "message_stop" in events
+
+    def test_content_block_types(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "Hello there"}],
+                    }
+                ],
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["type"] == "message"
+
+    def test_response_has_usage(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        body = response.json()
+        assert "usage" in body
+        assert "input_tokens" in body["usage"]
+        assert "output_tokens" in body["usage"]
+
+    def test_response_has_id(self):
+        response = client.post(
+            "/v1/messages",
+            json={
+                "model": "test",
+                "max_tokens": 100,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+        )
+        body = response.json()
+        assert body["id"].startswith("msg_")


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Using the vLLM conversion between /v1/messages and /v1/chat/completions as a template, this PR adds a similar feature to the NeMo Guardrails server. This allows for the use of the NeMo Guardrails server as the backend endpoint for Claude Code, e.g.:
```
❯ I've set up some PII filters to auto-redact email addresses, can you try to generate some more?

⏺ FYI, I've run a guardrail.

  Absolutely! Generating realistic test data for PII filters is a smart way to stress-test your regex or NLP-based redaction pipelines. Here
   are a few more sample email addresses, deliberately varied to cover common structural quirks that often challenge naive parsers:

  - <EMAIL_ADDRESS> (utilizes the standard plus-addressing syntax for filtering/tracking)
  - <EMAIL_ADDRESS> (combines an underscore with a multi-part local name)
  - <EMAIL_ADDRESS> (includes a numeric identifier and a nested subdomain structure)
  - <EMAIL_ADDRESS> (uses hyphens in the domain paired with a role-based prefix)
  - <EMAIL_ADDRESS> (mixes a role with a number and a modern application TLD)
  - <EMAIL_ADDRESS> (multiple periods, initials, and a hyphenated domain)
  - <EMAIL_ADDRESS> (longer, department-specific format with a year suffix)

  These are all safely fictional and routed through reserved or common test domains, so they won't attempt real delivery, but they should
  give your PII redaction layer a solid workout across different separators, lengths, casing, and structural edge cases.

  If you're building validation or parsing logic, I'd also recommend throwing in a few intentionally malformed or non-standard variations
  (like user@ or .hidden@domain..com) to ensure your filter gracefully rejects or flags them rather than crashing. Let me know if you need
  them batch-exported in CSV/JSON format, or if you want to test against case-insensitivity, UTF-8/Unicode email quirks, or
  internationalized domain names (IDNs)!
```


## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
