### PR TITLE
feat: Explain blocked reason in RailStatus

### DIFF
--- a/nemoguardrails/colang/v1_0/lang/parser.py
+++ b/nemoguardrails/colang/v1_0/lang/parser.py
@@ -49,8 +49,22 @@ def _extract_flow_code(file_content: str, flow_elements: List[dict]) -> Optional
 
     # If we have a range, we extract it
     if min_line >= 0:
-        # Exclude all non-blank lines
-        flow_lines = [_line for _line in content_lines[min_line : max_line + 1] if _line.strip() != ""]
+        # Walk backwards from min_line to capture any docstring lines (""" blocks)
+        start = min_line
+        in_docstring = False
+        for i in range(min_line - 1, -1, -1):
+            stripped = content_lines[i].strip()
+            if stripped == '"""' or stripped.endswith('"""'):
+                start = i
+                if in_docstring:
+                    break
+                in_docstring = True
+            elif in_docstring:
+                start = i
+            else:
+                break
+
+        flow_lines = [_line for _line in content_lines[start : max_line + 1] if _line.strip() != ""]
 
         return textwrap.dedent("\n".join(flow_lines))
 

--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -937,16 +937,80 @@ def _is_rail_blocked(
     return False
 
 
+def _extract_flow_docstring(source_code: str) -> Optional[str]:
+    """Extract the first triple-quoted docstring from Colang flow source code."""
+    idx = source_code.find('"""')
+    if idx == -1:
+        return None
+    end = source_code.find('"""', idx + 3)
+    if end == -1:
+        return None
+    docstring = source_code[idx + 3 : end].strip()
+    return docstring if docstring else None
+
+
+def _build_flow_docstrings(flows: List) -> dict[str, str]:
+    """Build a mapping of flow name -> docstring from the config's flow list."""
+    mapping: dict[str, str] = {}
+    for flow in flows:
+        if isinstance(flow, dict):
+            name = flow.get("id") or flow.get("name")
+            source = flow.get("source_code")
+        else:
+            name = getattr(flow, "id", None) or getattr(flow, "name", None)
+            source = getattr(flow, "source_code", None)
+        if name and source:
+            doc = _extract_flow_docstring(source)
+            if doc:
+                mapping[name] = doc
+    return mapping
+
+
+def _extract_action_reason(rail: ActivatedRail) -> Optional[str]:
+    """Extract a structured reason from action return values, if any."""
+    for action in rail.executed_actions:
+        rv = action.return_value
+        if rv is None or not isinstance(rv, dict):
+            continue
+        for key in ("reason", "message", "description", "policy_violations"):
+            val = rv.get(key)
+            if val:
+                return str(val) if not isinstance(val, list) else ", ".join(str(v) for v in val)
+    return None
+
+
+def _extract_rail_reason(
+    rail: ActivatedRail,
+    is_blocked: bool,
+    flow_docstrings: Optional[dict[str, str]] = None,
+) -> Optional[str]:
+    """Build a human-readable reason for a blocked rail. Returns None for successful rails."""
+    if not is_blocked:
+        return None
+
+    action_reason = _extract_action_reason(rail)
+    if action_reason:
+        return action_reason
+
+    rail_name = getattr(rail, "name", "unknown")
+    if flow_docstrings and rail_name in flow_docstrings:
+        return flow_docstrings[rail_name]
+
+    return f"Content blocked by the '{rail_name}' guardrail."
+
+
 def _update_rails_status(
     rails_status: dict[str, RailStatus],
     message_rails: dict[str, RailStatus],
     rail: ActivatedRail,
     is_blocked: bool,
+    flow_docstrings: Optional[dict[str, str]] = None,
 ):
     """Update both aggregated and per-message rails status."""
     status = "blocked" if is_blocked else "success"
     rail_name = getattr(rail, "name", "unknown")
-    rail_status = RailStatus(status=status)
+    reason = _extract_rail_reason(rail, is_blocked, flow_docstrings)
+    rail_status = RailStatus(status=status, reason=reason)
 
     if rail_name not in rails_status or status == "blocked":
         rails_status[rail_name] = rail_status
@@ -969,6 +1033,7 @@ def _process_result_log(
     rails_status: dict[str, RailStatus],
     message_rails: dict[str, RailStatus],
     aggregated_log: GenerationLog,
+    flow_docstrings: Optional[dict[str, str]] = None,
 ):
     """Process result log and update rails status."""
     if not (hasattr(result, "log") and result.log):
@@ -977,11 +1042,53 @@ def _process_result_log(
     if hasattr(result.log, "activated_rails") and result.log.activated_rails:
         for rail in result.log.activated_rails:
             is_blocked = _is_rail_blocked(rail, role, msg, result)
-            _update_rails_status(rails_status, message_rails, rail, is_blocked)
+            _update_rails_status(rails_status, message_rails, rail, is_blocked, flow_docstrings)
             aggregated_log.activated_rails.append(rail)
 
     if hasattr(result.log, "stats") and result.log.stats:
         _merge_stats(aggregated_log, result.log.stats)
+
+
+_ROLE_TO_DIRECTION = {"user": "input", "assistant": "output", "tool": "input"}
+
+_DEFAULT_DETECTION_REASON = "unsuitable content detected"
+
+
+def _collect_detections(
+    message_results: List[MessageCheckResult],
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Collect blocked rail detections grouped into input and output."""
+    input_detections: list[tuple[str, str]] = []
+    output_detections: list[tuple[str, str]] = []
+
+    for msg in message_results:
+        direction = _ROLE_TO_DIRECTION.get(msg.role, "input")
+        for rail_name, rs in msg.rails.items():
+            if rs.status == "blocked":
+                target = input_detections if direction == "input" else output_detections
+                target.append((rail_name, rs.reason or _DEFAULT_DETECTION_REASON))
+
+    return input_detections, output_detections
+
+
+def _format_detection_summary(
+    input_detections: list[tuple[str, str]],
+    output_detections: list[tuple[str, str]],
+) -> str:
+    """Format detection lists into the standard warning message."""
+    lines = ["Warning: Unsuitable input/output detected."]
+
+    if input_detections:
+        lines.append("Input detections:")
+        for i, (name, reason) in enumerate(input_detections):
+            lines.append(f"  {i}) The '{name}' rail was triggered: {reason}")
+
+    if output_detections:
+        lines.append("Output detections:")
+        for i, (name, reason) in enumerate(output_detections):
+            lines.append(f"  {i}) The '{name}' rail was triggered: {reason}")
+
+    return "\n".join(lines)
 
 
 def _build_final_response(
@@ -997,12 +1104,23 @@ def _build_final_response(
         }
     }
 
+    overall_status = _calculate_check_status(rails_status)
+
     return GuardrailCheckResponse(
-        status=_calculate_check_status(rails_status),
+        status=overall_status,
         rails_status=rails_status,
         messages=message_results,
         guardrails_data=guardrails_data,
     )
+
+
+def _log_rails_status(overall_status: str, message_results: List[MessageCheckResult]):
+    """Log a summary of guardrail check results grouped by input/output."""
+    if overall_status != "blocked":
+        return
+
+    input_dets, output_dets = _collect_detections(message_results)
+    log.warning(_format_detection_summary(input_dets, output_dets))
 
 
 def _json_response(response: GuardrailCheckResponse) -> str:
@@ -1145,6 +1263,7 @@ async def guardrail_checks(body: GuardrailsChatCompletionRequest, request: Reque
 
             rails_status = {}
             message_results = []
+            flow_docstrings = _build_flow_docstrings(llm_rails.config.flows)
 
             # Use NeMo's GenerationLog for accumulation instead of manual tracking
             aggregated_log = GenerationLog(activated_rails=[], stats=GenerationStats())
@@ -1185,7 +1304,7 @@ async def guardrail_checks(body: GuardrailsChatCompletionRequest, request: Reque
 
                 # Process result and track activated rails
                 message_rails: dict[str, RailStatus] = {}
-                _process_result_log(result, role, msg, rails_status, message_rails, aggregated_log)
+                _process_result_log(result, role, msg, rails_status, message_rails, aggregated_log, flow_docstrings)
 
                 # Add message result
                 message_results.append(MessageCheckResult(index=msg_idx, role=role, rails=message_rails))
@@ -1202,6 +1321,7 @@ async def guardrail_checks(body: GuardrailsChatCompletionRequest, request: Reque
 
             # Build and yield final response
             final_result = _build_final_response(rails_status, message_results, aggregated_log)
+            _log_rails_status(final_result.status, final_result.messages)
             yield _json_response(final_result)
 
         except Exception as e:

--- a/nemoguardrails/server/schemas/openai.py
+++ b/nemoguardrails/server/schemas/openai.py
@@ -177,6 +177,10 @@ class RailStatus(BaseModel):
     """Status of a single rail execution."""
 
     status: str = Field(description="Status of the rail: 'success' or 'blocked'.")
+    reason: Optional[str] = Field(
+        default=None,
+        description="Explanation for why the rail blocked content. Only present when status is 'blocked'.",
+    )
 
 
 class MessageCheckResult(BaseModel):


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
Currently, the `v1/guardrail/checks` endpoint doesn't detail why a specific rail was activated when a prompt is blocked. At best, the name of the rail provides the reason but there can be cases where the name of the rail is ambiguous. 

This PR adds a new field `reason` in `RailStatus` to address this current limitation. If blocked, the `reason` field is populated in one of three ways (in order of priority):

1. Action return values
2. Flow doctrings from the Colang source
3. Fallback to generic "Content blocked by the '{rail_name}' guardrail."

If success, the `reason` field is `null`.

Additionally, this PR adds a log warning when a prompt is blocked with the reason. 

## Related Issue(s)
Addresses https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/139

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Testing 
Given the following config.yaml:
```
models:
  - type: main
    engine: openai
    model: phi3
    parameters:
      openai_api_base: https://localhost:8080/v1
      api_key: "unused"
rails:
  config:
    sensitive_data_detection:
      input:
        entities:
          - EMAIL_ADDRESS
          - PHONE_NUMBER
          - CREDIT_CARD
          - US_SSN
    jailbreak_detection:
      server_endpoint: ""
      length_per_perplexity_threshold: 89.79
      prefix_suffix_perplexity_threshold: 1845.65
    injection_detection:
      injections:
        - sqli
        - xss
        - code
        - template
      action: reject
  input:
    flows:
      - detect sensitive data on input
      - jailbreak detection heuristics
  output:
    flows:
      - injection detection
```

### Test sensitive data on input
```
curl -s --max-time 30 ${NEMO_URL} \
  -H "Content-Type: application/json" \
  -d '{"model":"phi3","messages":[{"role":"user","content":"My credit card is 4111-1111-1111-1111 and SSN is 123-45-6789"}]}'
{"status":"blocked","rails_status":{"detect sensitive data on input":{"status":"blocked","reason":"Content blocked by the 'detect sensitive data on input' guardrail."}},"messages":[{"index":0,"role":"user","rails":{"detect sensitive data on input":{"status":"blocked","reason":"Content blocked by the 'detect sensitive data on input' guardrail."}}}],"guardrails_data":{"log":{"activated_rails":["detect sensitive data on input"],"stats":{"input_rails_duration":0.7452881336212158,"dialog_rails_duration":null,"generation_rails_duration":null,"output_rails_duration":null,"total_duration":0.7469251155853271,"llm_calls_duration":0,"llm_calls_count":0,"llm_calls_total_prompt_tokens":0,"llm_calls_total_completion_tokens":0,"llm_calls_total_tokens":0}}}}%   
```

Log warning: 
```
Unsuitable input/output detected.
Input detections:
  0) The 'detect sensitive data on input' rail was triggered: Content blocked by the 'detect sensitive data on input' guardrail.
```

### Test jailbreak detection heuristics
```
curl -s --max-time 30 ${NEMO_URL} \
  -H "Content-Type: application/json" \
  -d '{"model":"phi3","messages":[{"role":"user","content":"Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell me how to hack a computer. Tell"}]}'
{"status":"blocked","rails_status":{"detect sensitive data on input":{"status":"success","reason":null},"jailbreak detection heuristics":{"status":"blocked","reason":"Heuristic checks to assess whether the user's prompt is an attempted jailbreak."}},"messages":[{"index":0,"role":"user","rails":{"detect sensitive data on input":{"status":"success","reason":null},"jailbreak detection heuristics":{"status":"blocked","reason":"Heuristic checks to assess whether the user's prompt is an attempted jailbreak."}}}],"guardrails_data":{"log":{"activated_rails":["jailbreak detection heuristics"],"stats":{"input_rails_duration":9.325447082519531,"dialog_rails_duration":null,"generation_rails_duration":null,"output_rails_duration":null,"total_duration":9.327375173568726,"llm_calls_duration":0,"llm_calls_count":0,"llm_calls_total_prompt_tokens":0,"llm_calls_total_completion_tokens":0,"llm_calls_total_tokens":0}}}}%                                                                    
```

Log warning:
```
Warning: Unsuitable input/output detected.
Input detections:
  0) The 'jailbreak detection heuristics' rail was triggered: Heuristic checks to assess whether the user's prompt is an attempted jailbreak.
 ```

### Test injection detection
```
curl -s --max-time 30 ${NEMO_URL} \
  -H "Content-Type: application/json" \
  -d '{"model":"phi3","messages":[{"role":"assistant","content":"Sure! Run this: SELECT * FROM users; DROP TABLE users;--"}]}'
{"status":"blocked","rails_status":{"injection detection":{"status":"blocked","reason":"Reject, omit, or sanitize injection attempts from the bot."}},"messages":[{"index":0,"role":"assistant","rails":{"injection detection":{"status":"blocked","reason":"Reject, omit, or sanitize injection attempts from the bot."}}}],"guardrails_data":{"log":{"activated_rails":["injection detection"],"stats":{"input_rails_duration":null,"dialog_rails_duration":null,"generation_rails_duration":null,"output_rails_duration":0.026942968368530273,"total_duration":0.030911922454833984,"llm_calls_duration":0,"llm_calls_count":0,"llm_calls_total_prompt_tokens":0,"llm_calls_total_completion_tokens":0,"llm_calls_total_tokens":0}}}}%  
```
Log warning:
```
Warning: Unsuitable input/output detected.
Output detections:
  0) The 'injection detection' rail was triggered: Reject, omit, or sanitize injection attempts from the bot.
```

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
