### PR TITLE
feat(api): Support input guardrail checks when role: 'system'

### DIFF
--- a/nemoguardrails/server/api.py
+++ b/nemoguardrails/server/api.py
@@ -1025,6 +1025,9 @@ async def _process_message(
     if role == "user":
         return None, _create_check_options(run_input=True)
 
+    if role == "system":
+        return None, _create_check_options(run_input=True)
+
     if role == "assistant":
         if "tool_calls" in msg:
             # Tool output rails - validate tool calls before execution
@@ -1038,7 +1041,7 @@ async def _process_message(
         return None, _create_check_options(run_tool_input=True)
 
     # Unsupported role
-    raise ValueError(f"Unsupported message role: '{role}'. Supported roles are: 'user', 'assistant', 'tool'.")
+    raise ValueError(f"Unsupported message role: '{role}'. Supported roles are: 'user', 'system', 'assistant', 'tool'.")
 
 
 def _build_check_messages(role: str, content: str, msg: dict) -> List[dict]:
@@ -1058,6 +1061,9 @@ def _build_check_messages(role: str, content: str, msg: dict) -> List[dict]:
     if role == "user":
         return [{"role": "user", "content": content}]
 
+    if role == "system":
+        return [{"role": "user", "content": content}]
+
     if role == "assistant":
         return [
             {"role": "user", "content": ""},
@@ -1070,7 +1076,7 @@ def _build_check_messages(role: str, content: str, msg: dict) -> List[dict]:
         return [tool_msg]
 
     # This should never be reached since _process_message validates the role first
-    raise ValueError(f"Unsupported message role: '{role}'. Supported roles are: 'user', 'assistant', 'tool'.")
+    raise ValueError(f"Unsupported message role: '{role}'. Supported roles are: 'user', 'system', 'assistant', 'tool'.")
 
 
 @app.post(
@@ -1082,6 +1088,7 @@ async def guardrail_checks(body: GuardrailsChatCompletionRequest, request: Reque
 
     This endpoint validates messages against configured guardrails using role-based routing:
     - user messages: evaluated by input rails
+    - system messages: evaluated by input rails
     - assistant messages: evaluated by output rails
     - tool messages: evaluated by tool_input rails
 
@@ -1110,6 +1117,7 @@ async def guardrail_checks(body: GuardrailsChatCompletionRequest, request: Reque
 
         Messages are checked independently based on role:
         - user messages: input rails
+        - system messages: input rails
         - assistant messages: output rails
         - tool messages: tool_input rails
         """

--- a/tests/test_guardrail_checks_api.py
+++ b/tests/test_guardrail_checks_api.py
@@ -338,13 +338,31 @@ def test_no_config_and_no_default():
     api.app.default_config_id = "simple_rails"
 
 
+def test_system_message_passes():
+    """System message triggers input rails and passes."""
+    response = client.post(
+        "/v1/guardrail/checks",
+        json={
+            "model": "test",
+            "messages": [{"role": "system", "content": "You are a helpful assistant"}],
+            "guardrails": {"config_id": "simple_rails"},
+        },
+    )
+
+    result = response.json()
+    assert result["status"] == "success"
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["role"] == "system"
+    assert result["messages"][0]["index"] == 0
+
+
 def test_unsupported_message_role():
     """Unsupported message role returns error."""
     response = client.post(
         "/v1/guardrail/checks",
         json={
             "model": "test",
-            "messages": [{"role": "system", "content": "You are a helpful assistant"}],
+            "messages": [{"role": "developer", "content": "some content"}],
             "guardrails": {"config_id": "simple_rails"},
         },
     )


### PR DESCRIPTION
## Description

This PR adds support for input guardrail checks for `system` messages. Currently, `system` is not included as a supported role for guardrail checks, however, this could be a glaring opportunity for prompt injection attacks. 

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)
- Fixes: https://github.com/opendatahub-io/ai-gateway-payload-processing/issues/205

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
