### PR TITLE
feat: add context bloat detection rail

### DIFF
--- a/nemoguardrails/library/context_bloat_detection/__init__.py
+++ b/nemoguardrails/library/context_bloat_detection/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/context_bloat_detection/actions.py
+++ b/nemoguardrails/library/context_bloat_detection/actions.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Context bloat detection action
+
+Detects context-manipulation attacks where attacker-controlled content
+(retrieved chunks, tool outputs, or user input) is padded, oversized,
+or repetitively structured to cause system prompt forgetting, bury instructions
+mid-context (harder to detect), or exhaust token budget.
+
+Checks:
+    * Size cap
+    * Entropy (sampling for very large inputs)
+    * Longest repeated character
+    * Repeated n-grams
+    * Check order:  size > entropy > run > repetition
+
+Wire as execution rail (tool output), retrieval rail (RAG chunks), or input rail.
+"""
+
+import logging
+import math
+from collections import Counter
+from typing import List, Optional, TypedDict
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions import action
+
+log = logging.getLogger(__name__)
+
+# Sample-based entropy for inputs above this size. Entropy is statistically
+# stable well below this threshold; sampling avoids O(n) work for huge inputs.
+ENTROPY_SAMPLE_THRESHOLD = 10000
+ENTROPY_SAMPLE_SIZE = 8000
+
+
+class ContextBloatResult(TypedDict):
+    is_bloat: bool
+    text: str
+    reason: Optional[str]
+    detections: List[str]
+    metrics: dict
+
+def _shannon_entropy(text: str) -> float:
+    """Shannon entropy (bits/char). Samples large inputs to bound runtime."""
+    if not text:
+        return 0.0
+    if len(text) > ENTROPY_SAMPLE_THRESHOLD:
+        # Stratified sample: head, middle, tail thirds
+        third = ENTROPY_SAMPLE_SIZE // 3
+        mid = len(text) // 2
+        sample = text[:third] + text[mid - third // 2 : mid + third // 2] + text[-third:]
+    else:
+        sample = text
+    counts = Counter(sample)
+    total = len(sample)
+    return -sum((c / total) * math.log2(c / total) for c in counts.values())
+
+
+def _repetition_ratio(text: str, n: int = 3) -> float:
+    """Fraction of repeated n-grams. High values are a padding-attack signature."""
+    if not text:
+        return 0.0
+    tokens = text.split()
+    if len(tokens) < n:
+        return 0.0
+    ngrams = [tuple(tokens[i:i + n]) for i in range(len(tokens) - n + 1)]
+    counter = Counter(ngrams)
+    repeated = sum(c - 1 for c in counter.values() if c > 1)
+    return repeated / len(ngrams) if ngrams else 0.0
+
+
+def _longest_run_ratio(text: str) -> float:
+    """Fraction of text that is the longest run of a single character.
+    """
+    if not text:
+        return 0.0
+    n = len(text)
+    longest = 1
+    i = 0
+    while i < n:
+        j = i + 1
+        while j < n and text[j] == text[i]:
+            j += 1
+        if j - i > longest:
+            longest = j - i
+        i = j
+    return longest / n
+
+
+def _validate_config(config: RailsConfig) -> None:
+    cfg = getattr(config.rails.config, "context_bloat_detection", None)
+    if cfg is None:
+        raise ValueError("context_bloat_detection configuration is missing in RailsConfig.")
+    if cfg.action not in {"reject", "truncate", "warn"}:
+        raise ValueError(
+            f"Expected 'reject', 'truncate', or 'warn' but got {cfg.action!r}."
+        )
+
+
+@action()
+async def context_bloat_detection(text: str, config: RailsConfig) -> ContextBloatResult:
+    """Detect context-bloat / context-manipulation attacks.
+    Check order is cheapest first to enable early-exit
+
+    Args:
+        text: The text to inspect (tool output, joined chunks, or user message).
+        config: RailsConfig with rails.config.context_bloat_detection settings.
+
+    Returns:
+        ContextBloatResult with is_bloat flag, processed text, reason, metrics.
+    """
+    _validate_config(config)
+    cfg = config.rails.config.context_bloat_detection
+
+    char_count = len(text) if text else 0
+    detections: List[str] = []
+    metrics: dict = {"chars": char_count}
+
+    # ---- 1. Size cap (truncate only applies here) ----
+    if char_count > cfg.max_chars:
+        detections.append("size_cap_exceeded")
+        log.info(f"context bloat detected: size_cap_exceeded | chars={char_count}")
+        if cfg.action == "reject":
+            return ContextBloatResult(
+                is_bloat=True,
+                text=text,
+                reason="size_cap_exceeded",
+                detections=detections,
+                metrics=metrics,
+            )
+        if cfg.action == "truncate":
+            text = text[: cfg.max_chars]
+
+    # ---- 2. Entropy ----
+    entropy = _shannon_entropy(text)
+    metrics["entropy"] = round(entropy, 3)
+    if entropy and entropy < cfg.min_entropy:
+        detections.append("low_entropy")
+        if cfg.action in ("reject", "truncate"):
+            log.info(f"context bloat detected: low_entropy | entropy={entropy:.3f}")
+            return ContextBloatResult(
+                is_bloat=True,
+                text=text,
+                reason="low_entropy",
+                detections=detections,
+                metrics=metrics,
+            )
+
+    # ---- 3. Longest run ----
+    run_ratio = _longest_run_ratio(text)
+    metrics["longest_run_ratio"] = round(run_ratio, 3)
+    if run_ratio > cfg.max_run_ratio:
+        detections.append("long_run")
+        if cfg.action in ("reject", "truncate"):
+            log.info(f"context bloat detected: long_run | run_ratio={run_ratio:.3f}")
+            return ContextBloatResult(
+                is_bloat=True,
+                text=text,
+                reason="long_run",
+                detections=detections,
+                metrics=metrics,
+            )
+
+    # ---- 4. N-gram repetition ----
+    rep_ratio = _repetition_ratio(text, n=cfg.ngram_size)
+    metrics["repetition_ratio"] = round(rep_ratio, 3)
+    if rep_ratio > cfg.max_repetition_ratio:
+        detections.append("high_repetition")
+
+    # ---- Aggregate result ----
+    is_bloat = bool(detections)
+    reason = ", ".join(detections) if detections else None
+
+    if is_bloat:
+        log.info(f"context bloat detected: {reason} | metrics={metrics}")
+
+    return ContextBloatResult(
+        is_bloat=is_bloat,
+        text=text,
+        reason=reason,
+        detections=detections,
+        metrics=metrics,
+    )

--- a/nemoguardrails/library/context_bloat_detection/config.yml
+++ b/nemoguardrails/library/context_bloat_detection/config.yml
@@ -1,0 +1,42 @@
+# Example config.yml for context_bloat_detection wiring.
+# Drop this into your config.yml under the existing models/rails keys.
+
+rails:
+  retrieval:
+    flows:
+      - context bloat detection on retrieval
+
+  execution:
+    flows:
+      - context bloat detection on tool output
+
+  input:
+    flows:
+      - context bloat detection on input
+
+  config:
+    context_bloat_detection:
+      # Size cap (characters). Tune per use case.
+      # Typically <5k for well-scoped agents.
+      max_chars: 5000
+
+      # Shannon entropy floor (bits per char). English prose ~ 4.0-4.5;
+      # heavily padded/repetitive text drops below ~3.5.
+      min_entropy: 3.5
+
+      # Max ratio of repeated n-grams (0.0 - 1.0).
+      # > 0.4 indicates padding-style repetition.
+      max_repetition_ratio: 0.4
+
+      # Size of n-grams used for repetition detection.
+      ngram_size: 3
+
+      # Max ratio of longest single-char/token run vs total length.
+      # Catches "AAAAAA..." or whitespace padding.
+      max_run_ratio: 0.1
+
+      # Action on detection:
+      #   reject   -- stop the flow, return a user-facing message (recommended)
+      #   truncate -- truncate to max_chars at size cap, reject on remaining checks
+      #   warn     -- log only, do not modify
+      action: reject

--- a/nemoguardrails/library/context_bloat_detection/flows.co
+++ b/nemoguardrails/library/context_bloat_detection/flows.co
@@ -1,0 +1,37 @@
+
+# EXECUTION RAILS
+
+flow context bloat detection on tool output
+  """Detect oversized or padded tool responses before they reach the LLM."""
+  $bloat_result = await ContextBloatDetectionAction(text=$action_output)
+  if $bloat_result.is_bloat
+    bot inform tool output bloated
+    abort
+
+flow bot inform tool output bloated
+  bot say "The tool response appeared oversized or padded with repetitive content. I'm not using it to avoid context manipulation."
+
+# RETRIEVAL RAILS
+
+flow context bloat detection on retrieval
+  """Detect bloated or padded content in retrieved RAG chunks."""
+  $chunks_text = join($relevant_chunks, "\n\n")
+  $bloat_result = await ContextBloatDetectionAction(text=$chunks_text)
+  if $bloat_result.is_bloat
+    bot inform retrieval bloated
+    abort
+
+flow bot inform retrieval bloated
+  bot say "The retrieved sources for this question appeared oversized or padded. I'm not using them to avoid context manipulation."
+
+# INPUT RAILS
+
+flow context bloat detection on input
+  """Detect bloated or padded user-supplied content."""
+  $bloat_result = await ContextBloatDetectionAction(text=$user_message)
+  if $bloat_result.is_bloat
+    bot refuse bloated input
+    abort
+
+flow bot refuse bloated input
+  bot say "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."

--- a/nemoguardrails/library/context_bloat_detection/flows.v1.co
+++ b/nemoguardrails/library/context_bloat_detection/flows.v1.co
@@ -1,0 +1,37 @@
+
+# EXECUTION RAILS
+
+define subflow context bloat detection on tool output
+  """Detect oversized or padded tool responses before they reach the LLM."""
+  $bloat_result = execute context_bloat_detection(text=$action_output)
+  if $bloat_result.is_bloat
+    bot inform tool output bloated
+    stop
+
+define bot inform tool output bloated
+  "The tool response appeared oversized or padded with repetitive content. I'm not using it to avoid context manipulation."
+
+# RETRIEVAL RAILS
+
+define subflow context bloat detection on retrieval
+  """Detect bloated or padded content in retrieved RAG chunks."""
+  $chunks_text = join($relevant_chunks, "\n\n")
+  $bloat_result = execute context_bloat_detection(text=$chunks_text)
+  if $bloat_result.is_bloat
+    bot inform retrieval bloated
+    stop
+
+define bot inform retrieval bloated
+  "The retrieved sources for this question appeared oversized or padded. I'm not using them to avoid context manipulation."
+
+# INPUT RAILS
+
+define subflow context bloat detection on input
+  """Detect bloated or padded user-supplied content."""
+  $bloat_result = execute context_bloat_detection(text=$user_message)
+  if $bloat_result.is_bloat
+    bot refuse bloated input
+    stop
+
+define bot refuse bloated input
+  "Your message appears oversized or padded with repetitive content. Please send a shorter message focused on your question."

--- a/nemoguardrails/rails/llm/config.py
+++ b/nemoguardrails/rails/llm/config.py
@@ -1049,6 +1049,35 @@ class ReasoningConfig(BaseModel):
     )
 
 
+class ContextBloatDetectionConfig(BaseModel):
+    """Configuration for context bloat / context manipulation detection."""
+
+    max_chars: int = Field(
+        default=5000,
+        description="Size cap in characters. Inputs exceeding this are flagged.",
+    )
+    min_entropy: float = Field(
+        default=3.5,
+        description="Shannon entropy floor (bits/char). English prose is ~4.0-4.5.",
+    )
+    max_repetition_ratio: float = Field(
+        default=0.4,
+        description="Max fraction of repeated n-grams (0.0-1.0).",
+    )
+    ngram_size: int = Field(
+        default=3,
+        description="Size of n-grams used for repetition detection.",
+    )
+    max_run_ratio: float = Field(
+        default=0.1,
+        description="Max fraction of text that is the longest single-char run.",
+    )
+    action: Literal["reject", "truncate", "warn"] = Field(
+        default="reject",
+        description="Action on detection: 'reject', 'truncate', or 'warn'.",
+    )
+
+
 class ContentSafetyConfig(BaseModel):
     """Configuration data for content safety rails."""
 
@@ -1149,6 +1178,11 @@ class RailsConfigData(BaseModel):
     content_safety: Optional[ContentSafetyConfig] = Field(
         default_factory=ContentSafetyConfig,
         description="Configuration for content safety rails.",
+    )
+
+    context_bloat_detection: Optional[ContextBloatDetectionConfig] = Field(
+        default_factory=ContextBloatDetectionConfig,
+        description="Configuration for context bloat / context manipulation detection.",
     )
 
 

--- a/tests/test_context_bloat_detection.py
+++ b/tests/test_context_bloat_detection.py
@@ -1,0 +1,305 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+from unittest.mock import MagicMock
+
+from nemoguardrails.rails.llm.config import (
+    ContextBloatDetectionConfig,
+    RailsConfigData,
+)
+from nemoguardrails.library.context_bloat_detection.actions import (
+    context_bloat_detection,
+    _shannon_entropy,
+    _repetition_ratio,
+    _longest_run_ratio,
+    _validate_config,
+)
+
+
+def _make_config(**overrides):
+    config = MagicMock()
+    config.rails.config = RailsConfigData(
+        context_bloat_detection=ContextBloatDetectionConfig(**overrides)
+    )
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Config default values
+# ---------------------------------------------------------------------------
+
+class TestConfigDefaults:
+    def test_default_values(self):
+        cfg = ContextBloatDetectionConfig()
+        assert cfg.max_chars == 5000
+        assert cfg.min_entropy == 3.5
+        assert cfg.max_repetition_ratio == 0.4
+        assert cfg.max_run_ratio == 0.1
+        assert cfg.ngram_size == 3
+        assert cfg.action == "reject"
+
+    def test_custom_values(self):
+        cfg = ContextBloatDetectionConfig(
+            max_chars=10000, ngram_size=4, action="truncate"
+        )
+        assert cfg.max_chars == 10000
+        assert cfg.ngram_size == 4
+        assert cfg.action == "truncate"
+
+    def test_registered_in_rails_config_data(self):
+        data = RailsConfigData()
+        assert data.context_bloat_detection is not None
+
+    def test_accessible_when_configured(self):
+        data = RailsConfigData(
+            context_bloat_detection=ContextBloatDetectionConfig()
+        )
+        assert data.context_bloat_detection is not None
+        assert data.context_bloat_detection.max_chars == 5000
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_valid_action_reject(self):
+        _validate_config(_make_config(action="reject"))
+
+    def test_valid_action_truncate(self):
+        _validate_config(_make_config(action="truncate"))
+
+    def test_valid_action_warn(self):
+        _validate_config(_make_config(action="warn"))
+
+    def test_invalid_action_raises_at_config_time(self):
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError, match="literal_error"):
+            ContextBloatDetectionConfig(action="bad_value")
+
+    def test_default_config_is_valid(self):
+        config = MagicMock()
+        config.rails.config = RailsConfigData()
+        _validate_config(config)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+class TestShannonEntropy:
+    def test_empty_string(self):
+        assert _shannon_entropy("") == 0.0
+
+    def test_single_char_repeated(self):
+        assert _shannon_entropy("aaaaaaa") == pytest.approx(0.0, abs=0.01)
+
+    def test_normal_english(self):
+        entropy = _shannon_entropy("The quick brown fox jumps over the lazy dog")
+        assert entropy > 3.5
+
+    def test_large_input_uses_sampling(self):
+        text = "abcdefghij" * 2000
+        entropy = _shannon_entropy(text)
+        assert entropy > 0.0
+
+
+class TestRepetitionRatio:
+    def test_no_repetition(self):
+        assert _repetition_ratio("one two three four five six") == 0.0
+
+    def test_high_repetition(self):
+        repeated = " ".join(["foo bar baz"] * 20)
+        ratio = _repetition_ratio(repeated)
+        assert ratio > 0.4
+
+    def test_too_few_tokens(self):
+        assert _repetition_ratio("one two") == 0.0
+
+    def test_custom_ngram_size(self):
+        text = "a b c d a b c d a b c d"
+        ratio_3 = _repetition_ratio(text, n=3)
+        ratio_4 = _repetition_ratio(text, n=4)
+        assert ratio_3 > 0.0
+        assert ratio_4 > 0.0
+
+
+class TestLongestRunRatio:
+    def test_empty_string(self):
+        assert _longest_run_ratio("") == 0.0
+
+    def test_no_runs(self):
+        ratio = _longest_run_ratio("abcdef")
+        assert ratio == pytest.approx(1 / 6)
+
+    def test_long_run(self):
+        ratio = _longest_run_ratio("a" * 90 + "bcdefghijk")
+        assert ratio == 0.9
+
+    def test_all_same(self):
+        assert _longest_run_ratio("aaaa") == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Main action — detection paths
+# ---------------------------------------------------------------------------
+
+class TestDetectSizeCap:
+    @pytest.mark.asyncio
+    async def test_reject_oversized(self):
+        config = _make_config(max_chars=100, action="reject")
+        result = await context_bloat_detection("x" * 200, config)
+        assert result["is_bloat"] is True
+        assert "size_cap_exceeded" in result["detections"]
+
+    @pytest.mark.asyncio
+    async def test_under_size_passes(self):
+        config = _make_config(max_chars=1000, action="reject")
+        result = await context_bloat_detection("short text", config)
+        assert "size_cap_exceeded" not in result["detections"]
+
+
+class TestDetectEntropy:
+    @pytest.mark.asyncio
+    async def test_low_entropy_detected(self):
+        config = _make_config(max_chars=50000, min_entropy=3.5, action="reject")
+        result = await context_bloat_detection("ab" * 500, config)
+        assert result["is_bloat"] is True
+        assert "low_entropy" in result["detections"]
+
+    @pytest.mark.asyncio
+    async def test_normal_entropy_passes(self):
+        config = _make_config(max_chars=50000, min_entropy=3.5, action="reject")
+        text = "The quick brown fox jumps over the lazy dog. " * 10
+        result = await context_bloat_detection(text, config)
+        assert "low_entropy" not in result["detections"]
+
+
+class TestDetectLongRun:
+    @pytest.mark.asyncio
+    async def test_long_run_detected(self):
+        config = _make_config(
+            max_chars=50000, min_entropy=0.1, max_run_ratio=0.1, action="reject"
+        )
+        padded = "a" * 90 + "hello world"
+        result = await context_bloat_detection(padded, config)
+        assert result["is_bloat"] is True
+        assert "long_run" in result["detections"]
+
+    @pytest.mark.asyncio
+    async def test_short_run_passes(self):
+        config = _make_config(
+            max_chars=50000, min_entropy=0.1, max_run_ratio=0.5, action="reject"
+        )
+        result = await context_bloat_detection("hello world", config)
+        assert "long_run" not in result["detections"]
+
+
+class TestDetectRepetition:
+    @pytest.mark.asyncio
+    async def test_high_repetition_detected(self):
+        config = _make_config(
+            max_chars=50000, min_entropy=1.0, max_run_ratio=0.5,
+            max_repetition_ratio=0.4, action="warn",
+        )
+        repeated = " ".join(["foo bar baz"] * 50)
+        result = await context_bloat_detection(repeated, config)
+        assert result["is_bloat"] is True
+        assert "high_repetition" in result["detections"]
+
+    @pytest.mark.asyncio
+    async def test_unique_text_passes(self):
+        config = _make_config(
+            max_chars=50000, min_entropy=1.0, max_run_ratio=0.5,
+            max_repetition_ratio=0.4, action="reject",
+        )
+        result = await context_bloat_detection(
+            "every single word here is different and unique in this sentence", config
+        )
+        assert "high_repetition" not in result["detections"]
+
+
+# ---------------------------------------------------------------------------
+# Action modes
+# ---------------------------------------------------------------------------
+
+class TestTruncateMode:
+    @pytest.mark.asyncio
+    async def test_truncates_to_max_chars(self):
+        config = _make_config(max_chars=50, action="truncate")
+        result = await context_bloat_detection("x" * 200, config)
+        assert result["is_bloat"] is True
+        assert len(result["text"]) == 50
+
+    @pytest.mark.asyncio
+    async def test_truncate_early_returns_on_entropy(self):
+        config = _make_config(max_chars=50000, min_entropy=5.0, action="truncate")
+        result = await context_bloat_detection("ab" * 500, config)
+        assert result["is_bloat"] is True
+        assert "low_entropy" in result["detections"]
+        assert "longest_run_ratio" not in result["metrics"]
+
+
+class TestWarnMode:
+    @pytest.mark.asyncio
+    async def test_warn_does_not_block(self, caplog):
+        config = _make_config(max_chars=10, action="warn")
+        with caplog.at_level(logging.INFO):
+            result = await context_bloat_detection("x" * 200, config)
+        assert result["is_bloat"] is True
+        assert result["text"] == "x" * 200
+        assert any("context bloat detected" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_warn_continues_all_checks(self):
+        config = _make_config(
+            max_chars=10, min_entropy=5.0, max_run_ratio=0.01,
+            max_repetition_ratio=0.01, action="warn",
+        )
+        repeated = " ".join(["foo bar baz"] * 50)
+        result = await context_bloat_detection(repeated, config)
+        assert result["is_bloat"] is True
+        assert len(result["detections"]) > 1
+
+
+# ---------------------------------------------------------------------------
+# Normal text passes all checks
+# ---------------------------------------------------------------------------
+
+class TestNormalTextPasses:
+    @pytest.mark.asyncio
+    async def test_normal_text_not_flagged(self):
+        config = _make_config()
+        result = await context_bloat_detection(
+            "Hello, how can I help you today?", config
+        )
+        assert result["is_bloat"] is False
+        assert result["reason"] is None
+        assert result["detections"] == []
+
+    @pytest.mark.asyncio
+    async def test_moderate_text_not_flagged(self):
+        config = _make_config()
+        text = (
+            "The weather today is sunny with a high of 75 degrees. "
+            "Scientists have discovered a new species of butterfly in the Amazon. "
+            "The stock market closed higher on strong earnings reports from tech companies. "
+            "A new study suggests that regular exercise can improve cognitive function. "
+        )
+        result = await context_bloat_detection(text, config)
+        assert result["is_bloat"] is False


### PR DESCRIPTION
## Summary
- Adds a new `context_bloat_detection` guardrail that detects context-manipulation attacks (padded, oversized, or repetitive content in tool outputs, RAG chunks, or user input)
- Checks (cheapest first): size cap, Shannon entropy, longest char run, n-gram repetition
- Supports `reject`, `truncate`, and `warn` actions via config
- Registers `ContextBloatDetectionConfig` Pydantic model in `RailsConfigData` with sensible defaults

## Test plan
- [ ] Verify config loads with default values
- [ ] Verify oversized, low-entropy, padded, and repetitive inputs are detected
- [ ] Verify `truncate` mode truncates to `max_chars`
- [ ] Verify `warn` mode logs but does not block
- [ ] Verify normal text passes all checks