### PR TITLE
feat: Add tool call and tool response rails to self_check library

### DIFF
--- a/nemoguardrails/library/self_check/tool_call_check/__init__.py
+++ b/nemoguardrails/library/self_check/tool_call_check/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/self_check/tool_call_check/actions.py
+++ b/nemoguardrails/library/self_check/tool_call_check/actions.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+from typing import Optional
+
+from langchain_core.language_models.llms import BaseLLM
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions import action
+from nemoguardrails.actions.llm.utils import llm_call
+from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.llm.types import Task
+from nemoguardrails.logging.explain import LLMCallInfo
+
+log = logging.getLogger(__name__)
+
+
+@action(is_system_action=True, output_mapping=lambda value: not value)
+async def self_check_tool_call(
+    llm_task_manager: LLMTaskManager,
+    context: Optional[dict] = None,
+    llm: Optional[BaseLLM] = None,
+    config: Optional[RailsConfig] = None,
+    **kwargs,
+):
+    """Checks if the tool calls from the bot should be allowed.
+
+    Prompt the LLM, using the `self_check_tool_call` task prompt, to determine if the tool
+    calls from the bot should be allowed or not.
+
+    The LLM call should return "yes" if the tool calls are bad and should be blocked
+    (this is consistent with self_check_input_prompt).
+
+    Returns:
+        True if the tool calls should be allowed, False otherwise.
+    """
+
+    _MAX_TOKENS = 3
+    tool_calls = context.get("tool_calls")
+    user_input = context.get("user_message")
+
+    task = Task.SELF_CHECK_TOOL_CALL
+
+    if tool_calls:
+        # Convert tool_calls to a readable string format
+        tool_calls_str = json.dumps(tool_calls, indent=2)
+
+        prompt = llm_task_manager.render_task_prompt(
+            task=task,
+            context={
+                "user_input": user_input,
+                "tool_calls": tool_calls_str,
+            },
+        )
+        stop = llm_task_manager.get_stop_tokens(task=task)
+        max_tokens = llm_task_manager.get_max_tokens(task=task)
+        max_tokens = max_tokens or _MAX_TOKENS
+
+        # Initialize the LLMCallInfo object
+        llm_call_info_var.set(LLMCallInfo(task=task.value))
+
+        response = await llm_call(
+            llm,
+            prompt,
+            stop=stop,
+            llm_params={
+                "temperature": config.lowest_temperature,
+                "max_tokens": max_tokens,
+            },
+        )
+
+        log.info(f"Tool call self-checking result is: `{response}`.")
+
+        # for sake of backward compatibility
+        # if the output_parser is not registered we will use the default one
+        if llm_task_manager.has_output_parser(task):
+            result = llm_task_manager.parse_task_output(task, output=response)
+        else:
+            result = llm_task_manager.parse_task_output(
+                task, output=response, forced_output_parser="is_content_safe"
+            )
+
+        result = result.text
+        is_safe = result[0]
+
+        return is_safe

--- a/nemoguardrails/library/self_check/tool_call_check/flows.co
+++ b/nemoguardrails/library/self_check/tool_call_check/flows.co
@@ -1,0 +1,15 @@
+
+flow self check tool call
+  """Check if the tool calls from the bot should be allowed.
+
+  This tool output rail uses LLM-based self-check to determine if the bot's
+  tool calls are safe and appropriate before execution.
+  """
+  $allowed = await SelfCheckToolCallAction
+
+  if not $allowed
+    if $system.config.enable_rails_exceptions
+      send ToolOutputRailException(message="Tool call not allowed. The tool call was blocked by the 'self check tool call' flow.")
+    else
+      bot refuse to respond
+      abort

--- a/nemoguardrails/library/self_check/tool_call_check/flows.v1.co
+++ b/nemoguardrails/library/self_check/tool_call_check/flows.v1.co
@@ -1,0 +1,17 @@
+define bot refuse to respond
+  "I'm sorry, I can't respond to that."
+
+define flow self check tool call
+  """Check if the tool calls from the bot should be allowed.
+
+  This tool output rail uses LLM-based self-check to determine if the bot's
+  tool calls are safe and appropriate before execution.
+  """
+  $allowed = execute self_check_tool_call
+
+  if not $allowed
+    if $config.enable_rails_exceptions
+      create event ToolOutputRailException(message="Tool call not allowed. The tool call was blocked by the 'self check tool call' flow.")
+    else
+      bot refuse to respond
+    stop

--- a/nemoguardrails/library/self_check/tool_response_check/__init__.py
+++ b/nemoguardrails/library/self_check/tool_response_check/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/nemoguardrails/library/self_check/tool_response_check/actions.py
+++ b/nemoguardrails/library/self_check/tool_response_check/actions.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Optional
+
+from langchain_core.language_models.llms import BaseLLM
+
+from nemoguardrails import RailsConfig
+from nemoguardrails.actions.actions import ActionResult, action
+from nemoguardrails.actions.llm.utils import llm_call
+from nemoguardrails.context import llm_call_info_var
+from nemoguardrails.llm.taskmanager import LLMTaskManager
+from nemoguardrails.llm.types import Task
+from nemoguardrails.logging.explain import LLMCallInfo
+from nemoguardrails.utils import new_event_dict
+
+log = logging.getLogger(__name__)
+
+
+@action(is_system_action=True)
+async def self_check_tool_response(
+    llm_task_manager: LLMTaskManager,
+    context: Optional[dict] = None,
+    llm: Optional[BaseLLM] = None,
+    config: Optional[RailsConfig] = None,
+    **kwargs,
+):
+    """Checks the tool response from a tool execution.
+
+    Prompt the LLM, using the `self_check_tool_response` task prompt, to determine if the tool
+    response should be allowed or not.
+
+    Returns:
+        True if the tool response should be allowed, False otherwise.
+    """
+
+    _MAX_TOKENS = 3
+    tool_message = context.get("tool_message")
+    tool_name = context.get("tool_name")
+    user_input = context.get("user_message")
+
+    task = Task.SELF_CHECK_TOOL_RESPONSE
+
+    if tool_message:
+        prompt = llm_task_manager.render_task_prompt(
+            task=task,
+            context={
+                "user_input": user_input,
+                "tool_name": tool_name,
+                "tool_message": tool_message,
+            },
+        )
+        stop = llm_task_manager.get_stop_tokens(task=task)
+        max_tokens = llm_task_manager.get_max_tokens(task=task)
+        max_tokens = max_tokens or _MAX_TOKENS
+
+        # Initialize the LLMCallInfo object
+        llm_call_info_var.set(LLMCallInfo(task=task.value))
+
+        response = await llm_call(
+            llm,
+            prompt,
+            stop=stop,
+            llm_params={
+                "temperature": config.lowest_temperature,
+                "max_tokens": max_tokens,
+            },
+        )
+
+        log.info(f"Tool response self-checking result is: `{response}`.")
+
+        # for sake of backward compatibility
+        # if the output_parser is not registered we will use the default one
+        if llm_task_manager.has_output_parser(task):
+            result = llm_task_manager.parse_task_output(task, output=response)
+        else:
+            result = llm_task_manager.parse_task_output(
+                task, output=response, forced_output_parser="is_content_safe"
+            )
+
+        result = result.text
+        is_safe = result[0]
+
+        if not is_safe:
+            return ActionResult(
+                return_value=False,
+                events=[
+                    new_event_dict(
+                        "mask_prev_tool_message", intent="unsafe tool response"
+                    )
+                ],
+            )
+
+        return is_safe

--- a/nemoguardrails/library/self_check/tool_response_check/flows.co
+++ b/nemoguardrails/library/self_check/tool_response_check/flows.co
@@ -1,0 +1,15 @@
+
+flow self check tool response
+  """Check if the tool response should be allowed.
+
+  This tool input rail uses LLM-based self-check to determine if the tool's
+  response is safe and appropriate before using it in the bot's response.
+  """
+  $allowed = await SelfCheckToolResponseAction
+
+  if not $allowed
+    if $system.config.enable_rails_exceptions
+      send ToolInputRailException(message="Tool response not allowed. The tool response was blocked by the 'self check tool response' flow.")
+    else
+      bot refuse to respond
+    abort

--- a/nemoguardrails/library/self_check/tool_response_check/flows.v1.co
+++ b/nemoguardrails/library/self_check/tool_response_check/flows.v1.co
@@ -1,0 +1,17 @@
+define bot refuse to respond
+  "I'm sorry, I can't respond to that."
+
+define flow self check tool response
+  """Check if the tool response should be allowed.
+
+  This tool input rail uses LLM-based self-check to determine if the tool's
+  response is safe and appropriate before using it in the bot's response.
+  """
+  $allowed = execute self_check_tool_response
+
+  if not $allowed
+    if $config.enable_rails_exceptions
+      create event ToolInputRailException(message="Tool response not allowed. The tool response was blocked by the 'self check tool response' flow.")
+    else
+      bot refuse to respond
+    stop

--- a/nemoguardrails/llm/types.py
+++ b/nemoguardrails/llm/types.py
@@ -48,3 +48,5 @@ class Task(Enum):
 
     SELF_CHECK_FACTS = "self_check_facts"
     SELF_CHECK_HALLUCINATION = "self_check_hallucination"
+    SELF_CHECK_TOOL_CALL = "self_check_tool_call"
+    SELF_CHECK_TOOL_RESPONSE = "self_check_tool_response"


### PR DESCRIPTION
Add support for tool_output and tool_input rails in the self_check library to enable LLM-based validation of tool calls and tool responses.

Changes:
- Add SELF_CHECK_TOOL_CALL and SELF_CHECK_TOOL_RESPONSE task types
- Create tool_call_check subdirectory with actions and flows
- Create tool_response_check subdirectory with actions and flows
- Support both Colang v1 and v2 syntax
- Add proper docstrings to all flows

This is part of RHOAIENG-59437 to extend all common library flows to support the 5 rail types (input, output, retrieval, tool_output, tool_input).

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
