### PR TITLE
Add tool_call and tool_response rails to regex library

### DIFF
--- a/nemoguardrails/library/regex/actions.py
+++ b/nemoguardrails/library/regex/actions.py
@@ -37,7 +37,7 @@ async def detect_regex_pattern(
     """Checks whether the provided text matches any forbidden regex pattern.
 
     Args:
-        source: The source for the text, i.e. "input", "output", "retrieval".
+        source: The source for the text, i.e. "input", "output", "retrieval", "tool_call", "tool_response".
         text: The text to check.
         config: The rails configuration object.
 
@@ -47,15 +47,17 @@ async def detect_regex_pattern(
             - text (str): The original text that was checked.
             - detections (List[str]): List of pattern strings that matched.
     """
-    if source not in ("input", "output", "retrieval"):
-        raise ValueError("source must be one of 'input', 'output', or 'retrieval'")
+    if source not in ("input", "output", "retrieval", "tool_call", "tool_response"):
+        raise ValueError("source must be one of 'input', 'output', 'retrieval', 'tool_call', or 'tool_response'")
 
     regex_config = config.rails.config.regex_detection
     if regex_config is None:
         log.warning("No regex_detection configuration found.")
         return RegexDetectionResult(is_match=False, text=text, detections=[])
 
-    options = getattr(regex_config, source, None)
+    # Map tool_call and tool_response to output options as they follow similar validation patterns
+    source_key = source if source in ("input", "output", "retrieval") else "output"
+    options = getattr(regex_config, source_key, None)
 
     if options is None:
         log.warning("No regex rails configuration found for source: %s", source)

--- a/nemoguardrails/library/regex/flows.co
+++ b/nemoguardrails/library/regex/flows.co
@@ -31,3 +31,28 @@ flow regex check retrieval
 
   if $result["is_match"]
     $relevant_chunks = ""
+
+
+# TOOL OUTPUT RAILS
+
+
+flow regex check tool call
+  """Check if the tool calls match any forbidden regex patterns."""
+  $tool_calls_text = str($tool_calls)
+  $result = await DetectRegexMatchAction(source="tool_call", text=$tool_calls_text)
+
+  if $result["is_match"]
+    bot refuse to respond
+    abort
+
+
+# TOOL INPUT RAILS
+
+
+flow regex check tool response
+  """Check if the tool response matches any forbidden regex patterns."""
+  $result = await DetectRegexMatchAction(source="tool_response", text=$tool_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    abort

--- a/nemoguardrails/library/regex/flows.v1.co
+++ b/nemoguardrails/library/regex/flows.v1.co
@@ -33,3 +33,28 @@ define subflow regex check retrieval
 
   if $result["is_match"]
     $relevant_chunks = ""
+
+
+# TOOL OUTPUT RAILS
+
+
+define subflow regex check tool call
+  """Check if the tool calls match any forbidden regex patterns."""
+  $tool_calls_text = str($tool_calls)
+  $result = execute detect_regex_pattern(source="tool_call", text=$tool_calls_text)
+
+  if $result["is_match"]
+    bot refuse to respond
+    stop
+
+
+# TOOL INPUT RAILS
+
+
+define subflow regex check tool response
+  """Check if the tool response matches any forbidden regex patterns."""
+  $result = execute detect_regex_pattern(source="tool_response", text=$tool_message)
+
+  if $result["is_match"]
+    bot refuse to respond
+    stop


### PR DESCRIPTION
This commit adds the missing rail types to ensure comprehensive coverage:
- regex check tool call
- regex check tool response

Changes:
- Updated flows.co (Colang v2) with TOOL OUTPUT and TOOL INPUT rails
- Updated flows.v1.co (Colang v1) with corresponding subflows
- Modified actions.py to accept "tool_call" and "tool_response" sources
- Tool call/response sources map to output options for validation

All flows now support the five standard rail types: ✅ input
✅ output
✅ retrieval
✅ tool_call (tool output)
✅ tool_response (tool input)

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/NVIDIA-NeMo/Guardrails/blob/develop/CONTRIBUTING.md) guidelines.
- [ ] I've updated the documentation if applicable.
- [ ] I've added tests if applicable.
- [ ] @mentions of the person or team responsible for reviewing proposed changes.
